### PR TITLE
app.py request handling + other improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from datetime import datetime  #alternative import time
 from flask_sqlalchemy import SQLAlchemy
 from flask_cors import CORS
 from dotenv import load_dotenv, find_dotenv
-from flask_socketio import SocketIO
+from flask_socketio import SocketIO, emit
 from flask import Flask, send_from_directory, json
 
 # pylint: disable=global-statement
@@ -86,7 +86,7 @@ def on_request(data): # pylint: disable=unused-argument
         'seconds': seconds
     }
 
-    socketio.emit("canvas_state", D, broadcast=True, include_self=True)
+    emit("canvas_state", D) # emit instead of socketio.emit to only respond to sending client
 
 
 @socketio.on("canvas_set")

--- a/app.py
+++ b/app.py
@@ -9,7 +9,6 @@ from flask_cors import CORS
 from dotenv import load_dotenv, find_dotenv
 from flask_socketio import SocketIO, emit
 from flask import Flask, send_from_directory, json
-from canvasstate import *
 
 # pylint: disable=global-statement
 #pylint: disable=missing-function-docstring

--- a/app.py
+++ b/app.py
@@ -4,12 +4,12 @@
 import os
 import base64
 from datetime import datetime  #alternative import time
+import hashlib
 from flask_sqlalchemy import SQLAlchemy
 from flask_cors import CORS
 from dotenv import load_dotenv, find_dotenv
 from flask_socketio import SocketIO, emit
 from flask import Flask, send_from_directory, json
-import hashlib
 
 # pylint: disable=global-statement
 #pylint: disable=missing-function-docstring
@@ -119,7 +119,10 @@ def on_set(data):
 @socketio.on("login_request")
 def on_login_request(data):
     # look through database for username & password:
-    result = models.User.query.filter_by(username=data['username'], password=data['password']).first()
+    result = models.User.query.filter_by(
+        username=data['username'],
+        password=data['password']
+    ).first()
     if result is None:
         # username or password is incorrect
         emit("login_response", {"status": 1})

--- a/app.py
+++ b/app.py
@@ -58,7 +58,12 @@ def on_connect():
 @socketio.on('chat_submit')
 def on_submit(data):
     print("recieved chat from " + data['message'])
-    socketio.emit("chat_update", data, broadcast=True, include_self=True)
+
+    result = models.User.query.filter_by(auth_token=data['userAuthentication']).first()
+    if result is not None: # only propagate chat if user authentication token is valid
+        socketio.emit("chat_update", data, broadcast=True)
+    else:
+        print("bad authentication token")
 
 @socketio.on('canvas_request')
 def on_request(data): # pylint: disable=unused-argument

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from flask_cors import CORS
 from dotenv import load_dotenv, find_dotenv
 from flask_socketio import SocketIO, emit
 from flask import Flask, send_from_directory, json
+from canvasstate import *
 
 # pylint: disable=global-statement
 #pylint: disable=missing-function-docstring
@@ -63,21 +64,11 @@ def on_submit(data):
 @socketio.on('canvas_request')
 def on_request(data): # pylint: disable=unused-argument
     print("received emit from canvas")
-    currentState = bytearray([12 for i in range(canvasstate.BOARD_SIZE**2)])
-    history = models.Canvas.query.all()
-    for pixel in history:
-        currentState[pixel.x_cord +
-                     (pixel.y_cord * canvasstate.BOARD_SIZE)] = pixel.color
-
-    #byte_array = CanvasState.getState()
-    byte_array = bytearray(currentState)
-    print(currentState)
+    byte_array = canvasstate.get_state()
     dimensions = canvasstate.BOARD_SIZE
-
     now = datetime.now()
     seconds = now.second
     minutes = now.minute
-
     encoded = base64.b64encode(byte_array)
     D = {
         'data': encoded.decode("ascii"),
@@ -93,16 +84,19 @@ def on_request(data): # pylint: disable=unused-argument
 def on_set(data):
     #current_time = time.time()
     now = datetime.now()
-    hours = now.hour
+    #hours = now.hour
     seconds = now.second
     minutes = now.minute
 
-    update = models.Canvas(hours=hours,
-                           x_cord=data['x'],
-                           y_cord=data['y'],
-                           color=data['color'])
-    db.session.add(update)
-    db.session.commit()
+    # update = models.Canvas(hours=hours,
+    #                        x_cord=data['x'],
+    #                        y_cord=data['y'],
+    #                        color=data['color'])
+    # db.session.add(update)
+    # db.session.commit()
+
+    canvasstate.set_pixel(minutes, seconds, data['x'], data['y'],data['color'])
+
     canvasstate.set_pixel(minutes, seconds, data['x'], data['y'],
                           data['color'])  #variable names subjedt to change
 

--- a/models.py
+++ b/models.py
@@ -8,7 +8,7 @@ class User(db.Model):  # pylint: disable=too-few-public-methods
     username = db.Column(db.String(80), unique=False, nullable=False)
     password = db.Column(db.String(80), nullable=False)
     auth_token = db.Column(db.String(255), unique=False, nullable=False)
-    pixel = db.Column(db.Integer, nullable=False)
+    last_placed = db.Column(db.Integer, nullable=False)
     pixel_num = db.Column(db.Integer, nullable=False)
 
     def __repr__(self):

--- a/models.py
+++ b/models.py
@@ -6,8 +6,8 @@ class User(db.Model):  # pylint: disable=too-few-public-methods
     '''User entry'''
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=False, nullable=False)
-    password = db.Column(db.String(80), nullable=False)
-    auth_token = db.Column(db.String(255), unique=False, nullable=False)
+    password = db.Column(db.String(256), nullable=False)
+    auth_token = db.Column(db.String(256), unique=False, nullable=False)
     last_placed = db.Column(db.Integer, nullable=False)
     pixel_num = db.Column(db.Integer, nullable=False)
 

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ export const socket = io();
 
 function App(props) {
     // eslint-disable-next-line react/prop-types
-    const { isLoggedIn, userAuthentication } = props;
+    const { isLoggedIn, userAuthentication, username } = props;
 
     // Render colorpicker and chat only after canvas loads
     // Set to useState(true) if you want to disable this for testing
@@ -68,7 +68,9 @@ function App(props) {
             && (
                 <div className="shadow container chat">
                     <Chat
-                        username={isLoggedIn ? 'Default User' : ''}
+                        isEnabled={isLoggedIn}
+                        username={username}
+                        userAuthentication={userAuthentication}
                     />
                 </div>
             )}

--- a/src/App.js
+++ b/src/App.js
@@ -59,6 +59,8 @@ function App(props) {
 
             <div className="container canvas">
                 <Canvas
+                    userAuthentication={userAuthentication}
+                    isLoggedIn={isLoggedIn}
                     setCanvasLoadState={setCanvasLoadState}
                     selectedColor={selectedColorRef}
                 />

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -14,6 +14,9 @@ import loadingCircle from './graphics/loading_circle.gif';
 
 // eslint-disable-next-line import/prefer-default-export
 export function Canvas(props) {
+    // PROPS
+    const { userAuthentication, isLoggedIn } = props;
+
     // STATES
     const [mode, setMode] = useState(0); // current mode of canvas:
     //  0 - Obtaining canvas data...
@@ -45,14 +48,17 @@ export function Canvas(props) {
     let responseTimeout;
 
     function placePixel() {
-        // send a socketio emit canvas_set
-        if (selectedPixelRef.current[0] !== -1 && selectedPixelRef.current[1] !== -1
-            && props.selectedColor.current !== -1) {
-            socket.emit('canvas_set', {
-                x: selectedPixelRef.current[1],
-                y: selectedPixelRef.current[0],
-                color: props.selectedColor.current,
-            });
+        if (isLoggedIn) { // final check just incase before sending pixel placement event
+            // send a socketio emit canvas_set
+            if (selectedPixelRef.current[0] !== -1 && selectedPixelRef.current[1] !== -1
+                && props.selectedColor.current !== -1) {
+                socket.emit('canvas_set', {
+                    auth_token: userAuthentication,
+                    x: selectedPixelRef.current[1],
+                    y: selectedPixelRef.current[0],
+                    color: props.selectedColor.current,
+                });
+            }
         }
     }
 

--- a/src/Chat.js
+++ b/src/Chat.js
@@ -15,13 +15,13 @@ const socket = io();
 export default function Chat(props) {
     const [messageList, updateMessage] = useState([]);
     const inputRef = useRef(null);
-    const { username } = props;
+    const { username, isEnabled, userAuthentication } = props;
 
     function sendMessage() {
         if (inputRef !== null) {
             const message = inputRef.current.value;
             if (message !== '') {
-                socket.emit('chat_submit', { username, message: `${username}: ${message}` });
+                socket.emit('chat_submit', { userAuthentication, message: `${username}: ${message}` });
                 inputRef.current.value = '';
             }
         }
@@ -41,7 +41,7 @@ export default function Chat(props) {
 
     return (
         <div className="Chat">
-            {username ? (
+            {isEnabled ? (
                 <div className="messageList">
                     {messageList.map((message, index) => <ListChat key={index} message={message} />)}
                     <div className="chatbox">
@@ -54,9 +54,8 @@ export default function Chat(props) {
                     {
                         messageList.map((message, index) => <ListChat key={index} message={message} />)
                     }
-                    <div className="chatbox">
-                        <input placeholder=" Send a message" ref={inputRef} tyep="text" />
-                        <button type="button">Send</button>
+                    <div className="chatbox" style={{ width: '240px' }}>
+                        <p style={{ textAlign: 'center', flex: '1' }}>Log in to send messages</p>
                     </div>
                 </div>
             )}

--- a/src/Router.js
+++ b/src/Router.js
@@ -20,6 +20,7 @@ export function Router() {
                         <App
                             userAuthentication={userAuthentication}
                             isLoggedIn={isLoggedIn}
+                            username={username}
                         />
                     </Route>
                     <Route exact path="/signup">

--- a/src/Router.js
+++ b/src/Router.js
@@ -7,9 +7,10 @@ import App from './App';
 
 // eslint-disable-next-line import/prefer-default-export
 export function Router() {
+    // FOR TESTING, SIGN IN AS username='admin' with userAuthentication='abcdefg'
     const [userAuthentication, setUserAuth] = useState(null);
     const [isLoggedIn, setUserLoginStatus] = useState(false);
-    const [username, setUsername] = useState('Default User');
+    const [username, setUsername] = useState(null);
 
     return (
         <BrowserRouter>

--- a/src/TitleBar.js
+++ b/src/TitleBar.js
@@ -62,7 +62,7 @@ export function TitleBar(props) {
                     <button type="button" ref={buttonSignup} onClick={() => Navigate('signup')}>Signup</button>
                 </div>
             ) : (
-                <span className="Navigation">
+                <span className="Navigation" style={{ marginRight: '20px', marginTop: '7px' }}>
                     Logged in as
                     {'\u00A0'}
                     <b>{username}</b>

--- a/src/TitleBar.js
+++ b/src/TitleBar.js
@@ -20,6 +20,7 @@ export function TitleBar(props) {
     const buttonHistory = useRef(null);
     const buttonLogin = useRef(null);
     const buttonSignup = useRef(null);
+    const buttonTutorial = useRef(null);
 
     function Navigate(destination) {
         history.push(`/${destination}`);
@@ -31,6 +32,7 @@ export function TitleBar(props) {
 
             buttonCanvas.current.className = '';
             buttonHistory.current.className = '';
+            buttonTutorial.current.className = '';
             if (!isLoggedIn) {
                 buttonSignup.current.className = '';
                 buttonLogin.current.className = '';
@@ -44,6 +46,8 @@ export function TitleBar(props) {
                 if (!isLoggedIn) buttonSignup.current.className = 'selectedButton';
             } else if (p === '/login') {
                 if (!isLoggedIn) buttonLogin.current.className = 'selectedButton';
+            } else if (p === '/tutorial') {
+                buttonTutorial.current.className = 'selectedButton';
             }
         }
     }, [isLoggedIn, location]);
@@ -55,6 +59,7 @@ export function TitleBar(props) {
             <div className="Navigation middle">
                 <button type="button" ref={buttonCanvas} onClick={() => Navigate('')}>Canvas</button>
                 <button type="button" ref={buttonHistory} onClick={() => Navigate('history')}>History</button>
+                <button type="button" ref={buttonTutorial} onClick={() => Navigate('tutorial')}>Tutorial</button>
             </div>
             {!isLoggedIn ? (
                 <div className="Navigation">


### PR DESCRIPTION
### `app.py`

- Direct communication between server and client for certain _SocketIO_ requests rather than broadcasting.
- Database is no longer used to store canvas pixel state
- Chat & Canvas must provide valid authentication tokens with their requests to the server
- Server handling for login and signup requests
- Server handling for timer requests which allows client to obtain last time user placed a pixel

### Misc

- Added a 'Tutorial' tab to titlebar